### PR TITLE
fix for a Race condition

### DIFF
--- a/libSmeagol/nonVolatilePocket.py
+++ b/libSmeagol/nonVolatilePocket.py
@@ -29,6 +29,11 @@ class NonVolatilePocket(TimerPocket):
         # Start the timer
         self._startTimerThread()
 
+    ## @brief Allow setting of the base path storage location
+    @classmethod
+    def setStorageLocation(cls, *, base_path):
+        cls.__BASE_PATH = base_path
+
     ## Gets the filename, including the new path
     #  @return The fully qualified filename
     def getFilename(self) -> str:
@@ -45,13 +50,13 @@ class NonVolatilePocket(TimerPocket):
     #  @param restart_after_erase If true then the registryfile will be reopened and the thread started again
     def erase(self, *, restart_after_erase: bool = True) -> None:
         self.stop()
+        self._setPreferences({})
         try:
             log.info("Wiping all registry keys (%s)", self.__preferences_file)
             os.remove(self.__preferences_file)
         except OSError:
             log.exception("Unable to remove settings file (%s)", self.__preferences_file)
 
-        self._setPreferences({})
         if restart_after_erase:
             self.__load()
             self._start()

--- a/libSmeagol/timerPocket.py
+++ b/libSmeagol/timerPocket.py
@@ -33,6 +33,7 @@ class TimerPocket(Pocket):
     ## Stops the thread from running, but does not stop the thread itself
     def stop(self) -> None:
         self.__running = False
+        self.__thread.join()
 
     ## Protected
 
@@ -82,7 +83,7 @@ class TimerPocket(Pocket):
         self.__running = True
         thread_name = self._getRegistryId()
         log.info("Setting up thread '%s'", thread_name)
-        self.__thread = Thread(name=thread_name, target=self.__run, daemon=True)
+        self.__thread = Thread(name=thread_name, target=self.__run)
         self.__thread.start()
 
     ## During the existence of the instance, the running thread will be calling this function.


### PR DESCRIPTION
Due to the timing of the set-preferences and the stop not having a join the timer-pocket can time out causing a write.

The added function to set the base path makes it possible to replace the registry in the cluster service as well.